### PR TITLE
Added option to disable the function/variable name in phpDoc

### DIFF
--- a/plugin/php-doc.vim
+++ b/plugin/php-doc.vim
@@ -90,6 +90,7 @@ if !exists('g:pdv_cfg_CommentBlank') | let g:pdv_cfg_CommentBlank = " *" | endif
 if !exists('g:pdv_cfg_CommentTail') | let g:pdv_cfg_CommentTail = " */" | endif
 if !exists('g:pdv_cfg_CommentSingle') | let g:pdv_cfg_CommentSingle = "//" | endif
 if !exists('g:pdv_cfg_InsertFuncName') | let g:pdv_cfg_InsertFuncName = 1 | endif
+if !exists('g:pdv_cfg_InsertVarName') | let g:pdv_cfg_InsertVarName = 1 | endif
 if !exists('g:pdv_cfg_FuncCommentEnd') | let g:pdv_cfg_FuncCommentEnd = " // End function" | endif
 if !exists('g:pdv_cfg_ClassCommentEnd') | let g:pdv_cfg_ClassCommentEnd = " // End" | endif
 if !exists('g:pdv_cfg_VariableTypeTag') | let g:pdv_cfg_VariableTypeTag = "@var" | endif
@@ -458,8 +459,11 @@ func! PhpDocVar()
     let l:txtBOL = g:pdv_cfg_BOL . l:indent
 
     exe l:txtBOL . g:pdv_cfg_CommentHead . g:pdv_cfg_EOL
-    exe l:txtBOL . g:pdv_cfg_Comment1 . l:varname . " " . g:pdv_cfg_EOL
-    exe l:txtBOL . g:pdv_cfg_CommentBlank . g:pdv_cfg_EOL
+
+    if g:pdv_cfg_InsertVarName == 1
+        exe l:txtBOL . g:pdv_cfg_Comment1 . l:varname . " " . g:pdv_cfg_EOL
+        exe l:txtBOL . g:pdv_cfg_CommentBlank . g:pdv_cfg_EOL
+    endif
     if l:static != ""
         exe l:txtBOL . g:pdv_cfg_Commentn . "@static" . g:pdv_cfg_EOL
     endif

--- a/plugin/php-doc.vim
+++ b/plugin/php-doc.vim
@@ -89,6 +89,7 @@ if !exists('g:pdv_cfg_Commentn') | let g:pdv_cfg_Commentn = " * " | endif
 if !exists('g:pdv_cfg_CommentBlank') | let g:pdv_cfg_CommentBlank = " *" | endif
 if !exists('g:pdv_cfg_CommentTail') | let g:pdv_cfg_CommentTail = " */" | endif
 if !exists('g:pdv_cfg_CommentSingle') | let g:pdv_cfg_CommentSingle = "//" | endif
+if !exists('g:pdv_cfg_InsertFuncName') | let g:pdv_cfg_InsertFuncName = 1 | endif
 if !exists('g:pdv_cfg_FuncCommentEnd') | let g:pdv_cfg_FuncCommentEnd = " // End function" | endif
 if !exists('g:pdv_cfg_ClassCommentEnd') | let g:pdv_cfg_ClassCommentEnd = " // End" | endif
 if !exists('g:pdv_cfg_VariableTypeTag') | let g:pdv_cfg_VariableTypeTag = "@var" | endif
@@ -373,8 +374,10 @@ func! PhpDocFunc(end_line)
 
     exe l:txtBOL . g:pdv_cfg_CommentHead . g:pdv_cfg_EOL
     " added folding
-    exe l:txtBOL . g:pdv_cfg_Comment1 . funcname . g:pdv_cfg_EOL
-    exe l:txtBOL . g:pdv_cfg_CommentBlank . g:pdv_cfg_EOL
+    if g:pdv_cfg_InsertFuncName == 1
+        exe l:txtBOL . g:pdv_cfg_Comment1 . funcname . g:pdv_cfg_EOL
+        exe l:txtBOL . g:pdv_cfg_CommentBlank . g:pdv_cfg_EOL
+    endif
 
     while (l:parameters != ",") && (l:parameters != "")
         " Save 1st parameter


### PR DESCRIPTION
You can now use
`g:pdv_cfg_InsertFuncName = 0`
and
`g:pdv_cfg_InsertVarName = 0`
to disable inserting the function|variable name at the top of a function docblock.

For me this is just noise, so I needed a way to disable it. 